### PR TITLE
Feature/cc 25 user no password

### DIFF
--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,10 +1,11 @@
-import { Module } from "@nestjs/common";
+import { forwardRef, Module } from "@nestjs/common";
 import { AuthService } from "./auth.service";
 import { AuthController } from "./auth.controller";
 import { MongooseModule } from "@nestjs/mongoose";
 import { User, UserSchema } from "../users/schemas/user.schema";
 import { JwtModule } from "@nestjs/jwt";
 import { AccessTokenStrategy, RefreshTokenStrategy } from "./strategies";
+import { UserModule } from "../users/user.module";
 
 @Module({
   imports: [
@@ -15,6 +16,7 @@ import { AccessTokenStrategy, RefreshTokenStrategy } from "./strategies";
       },
     ]),
     JwtModule.register({}),
+    forwardRef(() => UserModule),
   ],
   providers: [AuthService, AccessTokenStrategy, RefreshTokenStrategy],
   controllers: [AuthController],

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,4 +1,4 @@
-import { ForbiddenException, Injectable } from "@nestjs/common";
+import { ForbiddenException, forwardRef, Inject, Injectable } from "@nestjs/common";
 import { InjectModel } from "@nestjs/mongoose";
 import { Model, ObjectId } from "mongoose";
 import { User } from "../users/schemas/user.schema";
@@ -8,12 +8,15 @@ import * as argon from "argon2";
 import { JwtService } from "@nestjs/jwt";
 import { CreateUserDto } from "src/users/dto/createUser.dto";
 import { sendEmail } from "./emailHelpers";
+import { UserService } from "../users/user.service";
 
 @Injectable()
 export class AuthService {
   constructor(
     @InjectModel(User.name) private readonly userModel: Model<User>,
     private jwtService: JwtService,
+    @Inject(forwardRef(() => UserService))
+    private userService: UserService,
   ) {}
 
   /**
@@ -62,6 +65,25 @@ export class AuthService {
       };
       // Return the user info who has been created when logging
       return newUserInfo;
+    } else if (!user.isActivated) {
+      await this.userService.updateUserById({
+        userId: user._id,
+        googleId: sub,
+        isActivated: true,
+      });
+      // get access token and refresh token
+      const tokens = await this.getTokens(user._id, user.email);
+      await this.updateRtHash(user._id, tokens.refreshToken);
+      const updatedUserInfo: ReturnUserInfo = {
+        userId: user._id,
+        googleId: sub,
+        email: email,
+        firstName: user.firstName,
+        lastName: user.lastName,
+        tokens,
+        needConnection: false,
+      };
+      return updatedUserInfo;
     } else {
       // get access token and refresh token
       const tokens = await this.getTokens(user._id, user.email);

--- a/src/users/dto/updateUser.dto.ts
+++ b/src/users/dto/updateUser.dto.ts
@@ -1,26 +1,33 @@
-import { IsEmpty, IsOptional, IsString } from "class-validator";
+import { IsBoolean, IsEmpty, IsOptional, IsString } from "class-validator";
 
 export class UpdateUserDto {
   @IsString()
-  @IsOptional()
   readonly userId: string;
 
   @IsString()
   @IsOptional()
-  readonly email: string;
+  readonly googleId?: string;
 
   @IsString()
   @IsOptional()
-  readonly password: string;
+  readonly email?: string;
 
   @IsString()
   @IsOptional()
-  readonly firstName: string;
+  readonly password?: string;
 
   @IsString()
   @IsOptional()
-  readonly lastName: string;
+  readonly firstName?: string;
+
+  @IsString()
+  @IsOptional()
+  readonly lastName?: string;
+
+  @IsBoolean()
+  @IsOptional()
+  readonly isActivated?: boolean;
 
   @IsEmpty()
-  readonly updatedAt: Date;
+  readonly updatedAt?: Date;
 }

--- a/src/users/dto/updateUser.dto.ts
+++ b/src/users/dto/updateUser.dto.ts
@@ -1,3 +1,26 @@
-import { CreateUserDto } from "./createUser.dto";
+import { IsEmpty, IsOptional, IsString } from "class-validator";
 
-export class UpdateUserDto extends CreateUserDto {}
+export class UpdateUserDto {
+  @IsString()
+  @IsOptional()
+  readonly userId: string;
+
+  @IsString()
+  @IsOptional()
+  readonly email: string;
+
+  @IsString()
+  @IsOptional()
+  readonly password: string;
+
+  @IsString()
+  @IsOptional()
+  readonly firstName: string;
+
+  @IsString()
+  @IsOptional()
+  readonly lastName: string;
+
+  @IsEmpty()
+  readonly updatedAt: Date;
+}

--- a/src/users/user.controller.ts
+++ b/src/users/user.controller.ts
@@ -6,6 +6,7 @@ import { User } from "./schemas/user.schema";
 import { UserService } from "./user.service";
 import { ConnectAccountDto } from "./dto/connectAccount.dto";
 import { ReturnUserInfo } from "../auth/ReturnUserInfo";
+import { UpdateUserDto } from "./dto/updateUser.dto";
 
 @Controller("user")
 export class UserController {
@@ -27,6 +28,11 @@ export class UserController {
   async getAllUsers(@Query() paginationQuery: PaginationQueryDto): Promise<User[]> {
     const { limit, offset } = paginationQuery;
     return await this.userService.getAllUsers(paginationQuery);
+  }
+
+  @Put()
+  async update(@Body() updateUser: UpdateUserDto) {
+    return await this.userService.updateUser(updateUser);
   }
 
   @Put("connect")

--- a/src/users/user.controller.ts
+++ b/src/users/user.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, HttpStatus, Post, Put, Query } from "@nestjs/common";
+import { Body, Controller, Get, Post, Put, Query } from "@nestjs/common";
 import { PaginationQueryDto } from "src/utils/PaginationDto/pagination-query.dto";
 import { CheckEmailDto } from "./dto/checkEmail.dto";
 import { CreateUserDto } from "./dto/createUser.dto";
@@ -15,6 +15,10 @@ export class UserController {
   async checkEmail(@Body() emailDto: CheckEmailDto): Promise<{
     findUser: boolean;
     needPwd: boolean;
+    emailRes: {
+      status: string;
+      message: string;
+    };
   }> {
     return await this.userService.checkEmail(emailDto);
   }
@@ -31,7 +35,7 @@ export class UserController {
   }
 
   @Put()
-  async update(@Body() updateUser: UpdateUserDto) {
+  async updateUser(@Body() updateUser: UpdateUserDto): Promise<User> {
     return await this.userService.updateUser(updateUser);
   }
 

--- a/src/users/user.controller.ts
+++ b/src/users/user.controller.ts
@@ -11,7 +11,10 @@ import { ReturnUserInfo } from "../auth/ReturnUserInfo";
 export class UserController {
   constructor(private readonly userService: UserService) {}
   @Post("status")
-  async checkEmail(@Body() emailDto: CheckEmailDto): Promise<boolean> {
+  async checkEmail(@Body() emailDto: CheckEmailDto): Promise<{
+    findUser: boolean;
+    needPwd: boolean;
+  }> {
     return await this.userService.checkEmail(emailDto);
   }
 

--- a/src/users/user.controller.ts
+++ b/src/users/user.controller.ts
@@ -36,7 +36,7 @@ export class UserController {
   }
 
   @Put()
-  async updateUser(@Body() updateUserDto: UpdateUserDto): Promise<User> {
+  async updateUserById(@Body() updateUserDto: UpdateUserDto): Promise<User> {
     return await this.userService.updateUserById(updateUserDto);
   }
 

--- a/src/users/user.controller.ts
+++ b/src/users/user.controller.ts
@@ -24,8 +24,8 @@ export class UserController {
   }
 
   @Post()
-  async create(@Body() createUser: CreateUserDto): Promise<User> {
-    return await this.userService.create(createUser);
+  async create(@Body() createUserDto: CreateUserDto): Promise<User> {
+    return await this.userService.create(createUserDto);
   }
 
   @Get()
@@ -35,12 +35,12 @@ export class UserController {
   }
 
   @Put()
-  async updateUser(@Body() updateUser: UpdateUserDto): Promise<User> {
-    return await this.userService.updateUser(updateUser);
+  async updateUser(@Body() updateUserDto: UpdateUserDto): Promise<User> {
+    return await this.userService.updateUser(updateUserDto);
   }
 
   @Put("connect")
-  async connectAccount(@Body() accountToConnect: ConnectAccountDto): Promise<ReturnUserInfo> {
-    return await this.userService.connectAccount(accountToConnect);
+  async connectAccount(@Body() connectAccountDto: ConnectAccountDto): Promise<ReturnUserInfo> {
+    return await this.userService.connectAccount(connectAccountDto);
   }
 }

--- a/src/users/user.controller.ts
+++ b/src/users/user.controller.ts
@@ -14,11 +14,12 @@ export class UserController {
   @Post("status")
   async checkEmail(@Body() emailDto: CheckEmailDto): Promise<{
     findUser: boolean;
-    needPwd: boolean;
-    emailRes: {
+    needPwd?: boolean;
+    emailRes?: {
       status: string;
       message: string;
     };
+    userId?: string;
   }> {
     return await this.userService.checkEmail(emailDto);
   }
@@ -36,7 +37,7 @@ export class UserController {
 
   @Put()
   async updateUser(@Body() updateUserDto: UpdateUserDto): Promise<User> {
-    return await this.userService.updateUser(updateUserDto);
+    return await this.userService.updateUserById(updateUserDto);
   }
 
   @Put("connect")

--- a/src/users/user.module.ts
+++ b/src/users/user.module.ts
@@ -1,4 +1,4 @@
-import { Module } from "@nestjs/common";
+import { forwardRef, Module } from "@nestjs/common";
 import { MongooseModule } from "@nestjs/mongoose";
 import { AuthModule } from "src/auth/auth.module";
 import { User, UserSchema } from "./schemas/user.schema";
@@ -13,9 +13,10 @@ import { UserService } from "./user.service";
         schema: UserSchema,
       },
     ]),
-    AuthModule,
+    forwardRef(() => AuthModule),
   ],
   providers: [UserService],
   controllers: [UserController],
+  exports: [UserService],
 })
 export class UserModule {}

--- a/src/users/user.service.spec.ts
+++ b/src/users/user.service.spec.ts
@@ -173,7 +173,7 @@ describe("UserService", () => {
     expect(updatedAccount.password).toEqual(updatedUser.password);
   });
 
-  it("should fail to update a user's password if no user", async () => {
+  it("should fail to update a user's password if no such user", async () => {
     jest.spyOn(model, "findById").mockReturnValueOnce(
       createMock<Query<any, any>>({
         exec: jest.fn().mockResolvedValueOnce(null),

--- a/src/users/user.service.spec.ts
+++ b/src/users/user.service.spec.ts
@@ -3,7 +3,13 @@ import { NotFoundException } from "@nestjs/common";
 import { getModelToken } from "@nestjs/mongoose";
 import { Test, TestingModule } from "@nestjs/testing";
 import { Model, Query } from "mongoose";
-import { connectedAccount, unconnectedAccount, updatedUser, userArray } from "./user.testData";
+import {
+  connectedAccount,
+  unconnectedAccount,
+  updatedUser,
+  user,
+  userArray,
+} from "./user.testData";
 import { User } from "./schemas/user.schema";
 import { UserService } from "./user.service";
 import { AuthService } from "src/auth/auth.service";
@@ -147,5 +153,49 @@ describe("UserService", () => {
     );
     const updatedUser = await service.connectAccount(unconnectedAccount);
     expect(updatedUser.googleId).toEqual(connectedAccount.googleId);
+  });
+
+  it("should update a user's password by id", async () => {
+    jest.spyOn(model, "findById").mockReturnValueOnce(
+      createMock<Query<any, any>>({
+        exec: jest.fn().mockResolvedValueOnce(user),
+      }) as any,
+    );
+    jest.spyOn(model, "findByIdAndUpdate").mockReturnValueOnce(
+      createMock<Query<any, any>>({
+        exec: jest.fn().mockResolvedValueOnce(updatedUser),
+      }) as any,
+    );
+    const updatedAccount = await service.updateUser({
+      userId: user.id,
+      password: updatedUser.password,
+      firstName: undefined,
+      lastName: undefined,
+      email: undefined,
+      updatedAt: undefined,
+    });
+    expect(updatedAccount.password).toEqual(updatedUser.password);
+  });
+
+  it("should update a user's password by email", async () => {
+    jest.spyOn(model, "findOne").mockReturnValueOnce(
+      createMock<Query<any, any>>({
+        exec: jest.fn().mockResolvedValueOnce(user),
+      }) as any,
+    );
+    jest.spyOn(model, "findByIdAndUpdate").mockReturnValueOnce(
+      createMock<Query<any, any>>({
+        exec: jest.fn().mockResolvedValueOnce(updatedUser),
+      }) as any,
+    );
+    const updatedAccount = await service.updateUser({
+      userId: undefined,
+      password: updatedUser.password,
+      firstName: undefined,
+      lastName: undefined,
+      email: user.email,
+      updatedAt: undefined,
+    });
+    expect(updatedAccount.password).toEqual(updatedUser.password);
   });
 });

--- a/src/users/user.service.spec.ts
+++ b/src/users/user.service.spec.ts
@@ -166,7 +166,7 @@ describe("UserService", () => {
         exec: jest.fn().mockResolvedValueOnce(updatedUser),
       }) as any,
     );
-    const updatedAccount = await service.updateUser({
+    const updatedAccount = await service.updateUserById({
       userId: user.id,
       password: updatedUser.password,
       firstName: undefined,
@@ -177,35 +177,8 @@ describe("UserService", () => {
     expect(updatedAccount.password).toEqual(updatedUser.password);
   });
 
-  it("should update a user's password by email", async () => {
-    jest.spyOn(model, "findOne").mockReturnValueOnce(
-      createMock<Query<any, any>>({
-        exec: jest.fn().mockResolvedValueOnce(user),
-      }) as any,
-    );
-    jest.spyOn(model, "findByIdAndUpdate").mockReturnValueOnce(
-      createMock<Query<any, any>>({
-        exec: jest.fn().mockResolvedValueOnce(updatedUser),
-      }) as any,
-    );
-    const updatedAccount = await service.updateUser({
-      userId: undefined,
-      password: updatedUser.password,
-      firstName: undefined,
-      lastName: undefined,
-      email: user.email,
-      updatedAt: undefined,
-    });
-    expect(updatedAccount.password).toEqual(updatedUser.password);
-  });
-
-  it("should fail to update a user's password if no id or password", async () => {
+  it("should fail to update a user's password if no user", async () => {
     jest.spyOn(model, "findById").mockReturnValueOnce(
-      createMock<Query<any, any>>({
-        exec: jest.fn().mockResolvedValueOnce(null),
-      }) as any,
-    );
-    jest.spyOn(model, "findOne").mockReturnValueOnce(
       createMock<Query<any, any>>({
         exec: jest.fn().mockResolvedValueOnce(null),
       }) as any,
@@ -216,7 +189,7 @@ describe("UserService", () => {
       }) as any,
     );
     await expect(
-      service.updateUser({
+      service.updateUserById({
         userId: undefined,
         password: updatedUser.password,
         firstName: undefined,

--- a/src/users/user.service.spec.ts
+++ b/src/users/user.service.spec.ts
@@ -120,13 +120,13 @@ describe("UserService", () => {
   });
 
   it("should check user by email", async () => {
-    jest.spyOn(model, "find").mockReturnValueOnce(
+    jest.spyOn(model, "findOne").mockReturnValueOnce(
       createMock<Query<any, any>>({
-        exec: jest.fn().mockResolvedValueOnce(userArray[0]),
+        exec: jest.fn().mockResolvedValueOnce(null),
       }) as any,
     );
-    const status = await service.checkEmail({ email: "test@gmail.com" });
-    expect(status).toEqual(false);
+    const status = await service.checkEmail({ email: "null@gmail.com" });
+    expect(status.findUser).toEqual(false);
   });
 
   it("should update a user's google ID", async () => {

--- a/src/users/user.service.spec.ts
+++ b/src/users/user.service.spec.ts
@@ -198,4 +198,32 @@ describe("UserService", () => {
     });
     expect(updatedAccount.password).toEqual(updatedUser.password);
   });
+
+  it("should fail to update a user's password if no id or password", async () => {
+    jest.spyOn(model, "findById").mockReturnValueOnce(
+      createMock<Query<any, any>>({
+        exec: jest.fn().mockResolvedValueOnce(null),
+      }) as any,
+    );
+    jest.spyOn(model, "findOne").mockReturnValueOnce(
+      createMock<Query<any, any>>({
+        exec: jest.fn().mockResolvedValueOnce(null),
+      }) as any,
+    );
+    jest.spyOn(model, "findByIdAndUpdate").mockReturnValueOnce(
+      createMock<Query<any, any>>({
+        exec: jest.fn().mockResolvedValueOnce(null),
+      }) as any,
+    );
+    await expect(
+      service.updateUser({
+        userId: undefined,
+        password: updatedUser.password,
+        firstName: undefined,
+        lastName: undefined,
+        email: undefined,
+        updatedAt: undefined,
+      }),
+    ).rejects.toThrow(`User not found`);
+  });
 });

--- a/src/users/user.service.spec.ts
+++ b/src/users/user.service.spec.ts
@@ -169,10 +169,6 @@ describe("UserService", () => {
     const updatedAccount = await service.updateUserById({
       userId: user.id,
       password: updatedUser.password,
-      firstName: undefined,
-      lastName: undefined,
-      email: undefined,
-      updatedAt: undefined,
     });
     expect(updatedAccount.password).toEqual(updatedUser.password);
   });
@@ -190,12 +186,8 @@ describe("UserService", () => {
     );
     await expect(
       service.updateUserById({
-        userId: undefined,
+        userId: "null",
         password: updatedUser.password,
-        firstName: undefined,
-        lastName: undefined,
-        email: undefined,
-        updatedAt: undefined,
       }),
     ).rejects.toThrow(`User not found`);
   });

--- a/src/users/user.service.ts
+++ b/src/users/user.service.ts
@@ -84,10 +84,10 @@ export class UserService {
    */
   async connectAccount(accountToConnectDto: ConnectAccountDto): Promise<ReturnUserInfo> {
     const existingUser = await this.userModel.findOne({ email: accountToConnectDto.email }).exec();
-    const id = existingUser._id;
     if (!existingUser || existingUser.isDeleted) {
-      throw new NotFoundException(`User ${id} not found`);
+      throw new NotFoundException(`User not found`);
     }
+    const id = existingUser._id;
     accountToConnectDto = { ...accountToConnectDto, updatedAt: new Date() };
     const connectedAccount = await this.userModel
       .findByIdAndUpdate({ _id: id }, { $set: accountToConnectDto }, { new: true })
@@ -144,9 +144,8 @@ export class UserService {
     const user = await this.userModel.findOne({ email: checkEmailDto.email }).exec();
     if (user) {
       const needPwd = !user.password;
-      let emailRes = null;
-      needPwd
-        ? (emailRes = await this.authService.sendOTPVerificationEmail(user._id, user.email))
+      const emailRes = needPwd
+        ? await this.authService.sendOTPVerificationEmail(user._id, user.email)
         : null;
       return {
         findUser: user.isActivated && !user.isDeleted,

--- a/src/users/user.service.ts
+++ b/src/users/user.service.ts
@@ -64,12 +64,11 @@ export class UserService {
     if (!user || user.isDeleted) {
       throw new NotFoundException(`User not found`);
     }
-
-    const password = updateUserDto.password;
-    const hashedPassword = password ? await argon.hash(password) : null;
     // Add new update date
     updateUserDto = { ...updateUserDto, updatedAt: new Date() };
-    updateUserDto = hashedPassword ? { ...updateUserDto, password: hashedPassword } : updateUserDto;
+    if (updateUserDto.password) {
+      updateUserDto = { ...updateUserDto, password: await argon.hash(updateUserDto.password) };
+    }
     const updatedUser = await this.userModel
       .findByIdAndUpdate({ _id: id }, { $set: updateUserDto }, { new: true })
       .exec();

--- a/src/users/user.service.ts
+++ b/src/users/user.service.ts
@@ -140,17 +140,28 @@ export class UserService {
   async checkEmail(emailDto: CheckEmailDto): Promise<{
     findUser: boolean;
     needPwd: boolean;
+    emailRes: {
+      status: string;
+      message: string;
+    };
   }> {
     const user = await this.userModel.findOne({ email: emailDto.email }).exec();
     if (user) {
+      const needPwd = !user.password;
+      let emailRes = null;
+      needPwd
+        ? (emailRes = await this.authService.sendOTPVerificationEmail(user._id, user.email))
+        : null;
       return {
         findUser: user.isActivated && !user.isDeleted,
-        needPwd: !user.password,
+        needPwd: needPwd,
+        emailRes: emailRes,
       };
     }
     return {
       findUser: false,
       needPwd: false,
+      emailRes: null,
     };
   }
 }

--- a/src/users/user.service.ts
+++ b/src/users/user.service.ts
@@ -133,8 +133,8 @@ export class UserService {
   }
 
   /**
-   * @findUser false if the user needs registration, true if not
-   * @needPwd
+   * @findUser false if the user needs registration
+   * @needPwd true if the user registered through google and does not have password
    * @param emailDto
    */
   async checkEmail(emailDto: CheckEmailDto): Promise<{

--- a/src/users/user.service.ts
+++ b/src/users/user.service.ts
@@ -22,8 +22,8 @@ export class UserService {
    * Get all users from database
    * @returns {[]:User}
    */
-  async getAllUsers(paginationQuery: PaginationQueryDto): Promise<User[]> {
-    const { limit, offset } = paginationQuery;
+  async getAllUsers(paginationQueryDto: PaginationQueryDto): Promise<User[]> {
+    const { limit, offset } = paginationQueryDto;
     const users = await this.userModel.find().skip(offset).limit(limit).exec();
     return users.filter((item) => !item.isDeleted);
   }
@@ -84,18 +84,18 @@ export class UserService {
 
   /**
    * connect account
-   * @param accountToConnect
+   * @param accountToConnectDto
    * @returns {User}
    */
-  async connectAccount(accountToConnect: ConnectAccountDto): Promise<ReturnUserInfo> {
-    const existingUser = await this.userModel.findOne({ email: accountToConnect.email }).exec();
+  async connectAccount(accountToConnectDto: ConnectAccountDto): Promise<ReturnUserInfo> {
+    const existingUser = await this.userModel.findOne({ email: accountToConnectDto.email }).exec();
     const id = existingUser._id;
     if (!existingUser || existingUser.isDeleted) {
       throw new NotFoundException(`User ${id} not found`);
     }
-    accountToConnect = { ...accountToConnect, updatedAt: new Date() };
+    accountToConnectDto = { ...accountToConnectDto, updatedAt: new Date() };
     const connectedAccount = await this.userModel
-      .findByIdAndUpdate({ _id: id }, { $set: accountToConnect }, { new: true })
+      .findByIdAndUpdate({ _id: id }, { $set: accountToConnectDto }, { new: true })
       .exec();
     // get access token and refresh token
     const tokens = await this.authService.getTokens(connectedAccount._id, connectedAccount.email);
@@ -135,9 +135,9 @@ export class UserService {
   /**
    * @findUser false if the user needs registration
    * @needPwd true if the user registered through google and does not have password
-   * @param emailDto
+   * @param checkEmailDto
    */
-  async checkEmail(emailDto: CheckEmailDto): Promise<{
+  async checkEmail(checkEmailDto: CheckEmailDto): Promise<{
     findUser: boolean;
     needPwd: boolean;
     emailRes: {
@@ -145,7 +145,7 @@ export class UserService {
       message: string;
     };
   }> {
-    const user = await this.userModel.findOne({ email: emailDto.email }).exec();
+    const user = await this.userModel.findOne({ email: checkEmailDto.email }).exec();
     if (user) {
       const needPwd = !user.password;
       let emailRes = null;

--- a/src/users/user.service.ts
+++ b/src/users/user.service.ts
@@ -122,17 +122,24 @@ export class UserService {
   }
 
   /**
-   * check if the users exist in database, if yes,
-   * Check if the user is not deleted and active by email.
+   * @findUser false if the user needs registration, true if not
+   * @needPwd
    * @param emailDto
    */
-  async checkEmail(emailDto: CheckEmailDto): Promise<boolean> {
-    const foundUser = await this.userModel.find({ email: emailDto.email }).exec();
-    if (foundUser.length > 0) {
-      const user = await this.userModel.findOne({ email: emailDto.email }).exec();
-      const { isActivated, isDeleted } = user;
-      return isActivated && !isDeleted;
+  async checkEmail(emailDto: CheckEmailDto): Promise<{
+    findUser: boolean;
+    needPwd: boolean;
+  }> {
+    const user = await this.userModel.findOne({ email: emailDto.email }).exec();
+    if (user) {
+      return {
+        findUser: user.isActivated && !user.isDeleted,
+        needPwd: !user.password,
+      };
     }
-    return false;
+    return {
+      findUser: false,
+      needPwd: false,
+    };
   }
 }

--- a/src/users/user.service.ts
+++ b/src/users/user.service.ts
@@ -60,17 +60,17 @@ export class UserService {
     let id = updateUserDto.userId;
     const email = updateUserDto.email;
     const password = updateUserDto.password;
-    let existingUser = null;
-    if (id != undefined) {
-      existingUser = await this.userModel.findById(id).exec();
-    } else if (email != undefined) {
-      existingUser = await this.userModel.findOne({ email: email }).exec();
+    let user = null;
+    if (id) {
+      user = await this.userModel.findById(id).exec();
+    } else if (email) {
+      user = await this.userModel.findOne({ email: email }).exec();
     }
     // if there is no such a user or the user has been deleted, then throw an error.
-    if (!existingUser || existingUser.isDeleted) {
+    if (!user || user.isDeleted) {
       throw new NotFoundException(`User not found`);
     }
-    id = id ? id : existingUser._id;
+    id = id ? id : user._id;
     const hashedPassword = password ? await argon.hash(password) : null;
     // Add new update date
     updateUserDto = { ...updateUserDto, updatedAt: new Date() };

--- a/src/users/user.service.ts
+++ b/src/users/user.service.ts
@@ -129,7 +129,7 @@ export class UserService {
 
   /**
    * @findUser false if the user needs registration
-   * @needPwd true if the user registered through google and does not have password
+   * @needPwd true if the user registered through google and does not have passwords
    * @param checkEmailDto
    */
   async checkEmail(checkEmailDto: CheckEmailDto): Promise<{


### PR DESCRIPTION
1. Resolve the situation where a user has already registered an account through google and then tries to log in through email. 

Previously, the app would indicate the user to input passwords. However, the user hasn't set passwords.

In the new version, the app will indicate user to set passwords after verifying the email.

2. Fix bugs when a user registers by email without finishing email verification (user is created in the database, but user.isActivated = false). Then this user tries to log in with google.

In the latest business logic (already finished previously), the user registering without verifying email shouldn't be seen as successfully registered on this user's side; this user should be indicated to register again as a brand new user when this user tries to register with the same email, although the information of this user is already saved in database.

However, when this user tries to log in with google in the above situation, the app will make a mistake to indicate this user to connect the account.

The bug above is fixed.


<img width="461" alt="image" src="https://user-images.githubusercontent.com/89760674/195336094-6c8b8dc6-2791-437b-830c-f8349a24bae3.png">
