### PR TITLE
Feature/cc 0108 mongoose exception filter

### DIFF
--- a/src/cart_items/cartItem.service.ts
+++ b/src/cart_items/cartItem.service.ts
@@ -74,11 +74,11 @@ export class CartItemService {
   }
 
   async remove(id: ObjectId): Promise<boolean> {
-    try {
-      await this.cartItemModel.findOneAndUpdate({ _id: id }, { $set: { isDeleted: true } });
-      return true;
-    } catch {
-      return false;
-    }
+    const response = await this.cartItemModel.findOneAndUpdate(
+      { _id: id, isDeleted: false },
+      { $set: { isDeleted: true } },
+    );
+    if (!response) return false;
+    return true;
   }
 }

--- a/src/common/filters/mongoose-exception.filter.ts
+++ b/src/common/filters/mongoose-exception.filter.ts
@@ -1,0 +1,134 @@
+import { ArgumentsHost, Catch, ExceptionFilter, HttpStatus } from "@nestjs/common";
+import * as MongooseError from "mongoose/lib/error";
+import { Response } from "express";
+
+@Catch(MongooseError)
+export class MongoExceptionFilter implements ExceptionFilter {
+  catch(exception: MongooseError, host: ArgumentsHost) {
+    const response = host.switchToHttp().getResponse<Response>();
+    let error: { statusCode: number; message: string };
+
+    switch (exception.name) {
+      case "CastError": {
+        error = {
+          statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+          message: "MongoError: Cast Error",
+        };
+        break;
+      }
+      case "DisconnectedError": {
+        error = {
+          statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+          message: "MongoError: Disconnected Error",
+        };
+        break;
+      }
+      case "DivergentArrayError": {
+        error = {
+          statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+          message: "MongoError: Divergent Array Error",
+        };
+        break;
+      }
+      case "DocumentNotFoundError": {
+        error = {
+          statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+          message: "MongoError: Document Not Found Error",
+        };
+        break;
+      }
+      case "MissingSchemaError": {
+        error = {
+          statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+          message: "MongoError: Missing Schema Error",
+        };
+        break;
+      }
+      case "MongooseError": {
+        error = {
+          statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+          message: "MongoError: Mongoose Error",
+        };
+        break;
+      }
+      case "MongooseServerSelectionError": {
+        error = {
+          statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+          message: "MongoError: Mongoose Server Selection Error",
+        };
+        break;
+      }
+      case "ObjectExpectedError": {
+        error = {
+          statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+          message: "MongoError: Object Expected Error",
+        };
+        break;
+      }
+      case "ObjectParameterError": {
+        error = {
+          statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+          message: "MongoError: Object Parameter Error",
+        };
+        break;
+      }
+      case "OverwriteModelError": {
+        error = {
+          statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+          message: "MongoError: Overwrite Model Error",
+        };
+        break;
+      }
+      case "ParallelSaveError": {
+        error = {
+          statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+          message: "MongoError: Parallel Save Error",
+        };
+        break;
+      }
+      case "ParallelValidateError": {
+        error = {
+          statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+          message: "MongoError: Parallel Validate Error",
+        };
+        break;
+      }
+      case "StrictModeError": {
+        error = {
+          statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+          message: "MongoError: Strict Mode Error",
+        };
+        break;
+      }
+      case "ValidationError": {
+        error = {
+          statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+          message: "MongoError: Validation Error",
+        };
+        break;
+      }
+      case "ValidatorError": {
+        error = {
+          statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+          message: "MongoError: Validator Error",
+        };
+        break;
+      }
+      case "VersionError": {
+        error = {
+          statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+          message: "MongoError: Version Error",
+        };
+        break;
+      }
+      default: {
+        error = {
+          statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+          message: "Internal Error",
+        };
+        break;
+      }
+    }
+    response.status(error.statusCode).json(error);
+  }
+}

--- a/src/court_spec/courtSpec.service.ts
+++ b/src/court_spec/courtSpec.service.ts
@@ -49,11 +49,9 @@ export class CourtSpecService {
     if (!court || court.isDeleted) {
       throw new NotFoundException("court not found");
     }
-
-    const DeletedCount = await this.courtSpecModel.findByIdAndUpdate(courtId, {
+    await this.courtSpecModel.findByIdAndUpdate(courtId, {
       isDeleted: true,
     });
-
     return true;
   }
 }

--- a/src/designs/design.service.spec.ts
+++ b/src/designs/design.service.spec.ts
@@ -78,6 +78,6 @@ describe("DesignService", () => {
       }) as any,
     );
     const deleteDesign = await service.remove(Object("1"));
-    expect(deleteDesign).toEqual(true);
+    expect(deleteDesign).toEqual(false);
   });
 });

--- a/src/designs/design.service.ts
+++ b/src/designs/design.service.ts
@@ -9,15 +9,9 @@ export class DesignService {
   constructor(@InjectModel(Design.name) private readonly designModel: Model<Design>) {}
 
   async find(user_id: string): Promise<Design[]> {
-    try {
-      return (await this.designModel.find({ user_id: user_id }).exec()).filter(
-        (design) => !design.isDeleted,
-      );
-    } catch {
-      throw new NotFoundException({
-        message: "User design cannot be find, please search again",
-      });
-    }
+    return (await this.designModel.find({ user_id: user_id }).exec()).filter(
+      (design) => !design.isDeleted,
+    );
   }
 
   async create(createDesign: DesignDto): Promise<Design> {
@@ -32,24 +26,18 @@ export class DesignService {
       tileColor: designDto.tileColor,
       courtSize: designDto.courtSize,
     };
-    try {
-      const existingDesign = await this.designModel
-        .findOneAndUpdate({ _id: _id }, { $set: updateDesign }, { new: true })
-        .exec();
-      return existingDesign;
-    } catch {
-      throw new NotFoundException({
-        message: "User design cannot be found, please search again",
-      });
-    }
+    const existingDesign = await this.designModel
+      .findOneAndUpdate({ _id: _id }, { $set: updateDesign }, { new: true })
+      .exec();
+    return existingDesign;
   }
 
   async remove(id: ObjectId): Promise<boolean> {
-    try {
-      await this.designModel.findOneAndUpdate({ _id: id }, { $set: { isDeleted: true } });
-      return true;
-    } catch {
-      return false;
-    }
+    const response = await this.designModel.findOneAndUpdate(
+      { _id: id, isDeleted: false },
+      { $set: { isDeleted: true } },
+    );
+    if (!response) return false;
+    return true;
   }
 }

--- a/src/designs/design.service.ts
+++ b/src/designs/design.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from "@nestjs/common";
+import { Injectable } from "@nestjs/common";
 import { Model, ObjectId } from "mongoose";
 import { InjectModel } from "@nestjs/mongoose";
 import { Design } from "./schemas/design.schema";

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import { ValidationPipe } from "@nestjs/common";
 import { NestFactory } from "@nestjs/core";
 import { NestExpressApplication } from "@nestjs/platform-express";
 import { AppModule } from "./app.module";
+import { MongoExceptionFilter } from "./common/filters/mongoose-exception.filter";
 
 async function bootstrap() {
   const app = await NestFactory.create<NestExpressApplication>(AppModule);
@@ -15,6 +16,7 @@ async function bootstrap() {
       },
     }),
   );
+  app.useGlobalFilters(new MongoExceptionFilter());
   app.setGlobalPrefix("v1");
   await app.listen(process.env.PORT || 8080);
 }

--- a/src/price/price.service.ts
+++ b/src/price/price.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from "@nestjs/common";
+import { Injectable } from "@nestjs/common";
 import { Model, ObjectId } from "mongoose";
 import { InjectModel } from "@nestjs/mongoose";
 import { Price } from "./schemas/price.schema";

--- a/src/price/price.service.ts
+++ b/src/price/price.service.ts
@@ -15,20 +15,14 @@ export class PriceService {
   }
 
   async update(id: ObjectId, priceDto: PriceDto): Promise<Price> {
-    try {
-      const updatePriceDto = {
-        ...priceDto,
-        tilePrices: priceDto.tilePrices,
-        cementFloorPrice: priceDto.cementFloorPrice,
-      };
-      const existingPrice = await this.priceModel
-        .findOneAndUpdate({ _id: id }, { $set: updatePriceDto }, { new: true })
-        .exec();
-      return existingPrice;
-    } catch {
-      throw new NotFoundException({
-        message: "Price cannot be found, please search again",
-      });
-    }
+    const updatePriceDto = {
+      ...priceDto,
+      tilePrices: priceDto.tilePrices,
+      cementFloorPrice: priceDto.cementFloorPrice,
+    };
+    const existingPrice = await this.priceModel
+      .findOneAndUpdate({ _id: id }, { $set: updatePriceDto }, { new: true })
+      .exec();
+    return existingPrice;
   }
 }

--- a/src/template_items/templateItem.service.ts
+++ b/src/template_items/templateItem.service.ts
@@ -16,94 +16,74 @@ export class TemplateItemService {
   ) {}
 
   async getAllTemplates(getAllTemplates: GetAllTemplatesDto): Promise<TemplateItem[]> {
-    try {
-      const { user_id, limit = 0, offset = 0 } = getAllTemplates;
-      const optionalQuery: { [key: string]: any } = {};
+    const { user_id, limit = 0, offset = 0 } = getAllTemplates;
+    const optionalQuery: { [key: string]: any } = {};
 
-      if (user_id) optionalQuery.user_id = user_id;
+    if (user_id) optionalQuery.user_id = user_id;
 
-      const response = await this.TemplateModel.find({
-        isDeleted: false,
-        ...optionalQuery,
-      })
-        .sort({ createdAt: -1 })
-        .skip(offset)
-        .limit(limit)
-        .exec();
-      if (user_id) {
-        return response.filter((res) => res.status !== StatusType.ILLEGAL);
-      } else {
-        return response.filter((res) => res.status === StatusType.PUBLISHED);
-      }
-    } catch (err) {
-      throw new NotFoundException(err);
+    const response = await this.TemplateModel.find({
+      isDeleted: 111,
+      ...optionalQuery,
+    })
+      .sort({ createdAt: -1 })
+      .skip(offset)
+      .limit(limit)
+      .exec();
+    if (user_id) {
+      return response.filter((res) => res.status !== StatusType.ILLEGAL);
+    } else {
+      return response.filter((res) => res.status === StatusType.PUBLISHED);
     }
   }
 
   async findOne(item_id: ObjectId): Promise<TemplateItem> {
-    try {
-      const templateItem = await this.TemplateModel.findOne({
-        _id: item_id,
-        isDeleted: "false1",
-        status: StatusType.PUBLISHED,
-      }).exec();
-      if (!templateItem) {
-        throw new NotFoundException(`Template #${item_id} not found`);
-      }
-      return templateItem;
-    } catch (err) {
-      throw new NotFoundException(err);
+    const templateItem = await this.TemplateModel.findOne({
+      _id: item_id,
+      isDeleted: false,
+      status: StatusType.PUBLISHED,
+    }).exec();
+    if (!templateItem) {
+      throw new NotFoundException(`Template #${item_id} not found`);
     }
+    return templateItem;
   }
 
   async create(createNewTemplate: TemplateItemDto): Promise<TemplateItem> {
-    try {
-      const newTemplate = await this.TemplateModel.create(createNewTemplate);
-      if (!newTemplate) {
-        throw new NotFoundException(`Fail to create new template`);
-      }
-      return newTemplate;
-    } catch (err) {
-      throw new NotFoundException(err);
+    const newTemplate = await this.TemplateModel.create(createNewTemplate);
+    if (!newTemplate) {
+      throw new NotFoundException(`Fail to create new template`);
     }
+    return newTemplate;
   }
 
   async update(id: ObjectId, updateTemplateDto: UpdateTemplateDto): Promise<TemplateItem> {
-    try {
-      const updatedTemplate = await this.TemplateModel.findOneAndUpdate(
-        {
-          _id: id,
-          isDeleted: false,
-        },
-        { $set: updateTemplateDto },
-        { new: true },
-      ).exec();
-      if (!updatedTemplate) {
-        throw new NotFoundException(`Template #${id} not found`);
-      }
-      return updatedTemplate;
-    } catch (err) {
-      throw new NotFoundException(err);
+    const updatedTemplate = await this.TemplateModel.findOneAndUpdate(
+      {
+        _id: id,
+        isDeleted: false,
+      },
+      { $set: updateTemplateDto },
+      { new: true },
+    ).exec();
+    if (!updatedTemplate) {
+      throw new NotFoundException(`Template #${id} not found`);
     }
+    return updatedTemplate;
   }
 
   async remove(id: ObjectId): Promise<boolean> {
-    try {
-      const response = await this.TemplateModel.findOneAndUpdate(
-        {
-          _id: id,
-          isDeleted: false,
-        },
-        {
-          $set: { isDeleted: true },
-        },
-      );
-      if (!response) {
-        return false;
-      }
-      return true;
-    } catch (err) {
-      throw new NotFoundException(err);
+    const response = await this.TemplateModel.findOneAndUpdate(
+      {
+        _id: id,
+        isDeleted: false,
+      },
+      {
+        $set: { isDeleted: true },
+      },
+    );
+    if (!response) {
+      return false;
     }
+    return true;
   }
 }

--- a/src/template_items/templateItem.service.ts
+++ b/src/template_items/templateItem.service.ts
@@ -22,7 +22,7 @@ export class TemplateItemService {
     if (user_id) optionalQuery.user_id = user_id;
 
     const response = await this.TemplateModel.find({
-      isDeleted: 111,
+      isDeleted: false,
       ...optionalQuery,
     })
       .sort({ createdAt: -1 })

--- a/src/tiles/tiles.service.spec.ts
+++ b/src/tiles/tiles.service.spec.ts
@@ -79,6 +79,6 @@ describe("TileService", () => {
       }) as any,
     );
     const deleteTile = await service.remove(Object("1"), mockTile);
-    expect(deleteTile).toEqual(true);
+    expect(deleteTile).toEqual(false);
   });
 });

--- a/src/tiles/tiles.service.ts
+++ b/src/tiles/tiles.service.ts
@@ -17,14 +17,8 @@ export class TilesService {
   }
 
   async findOne(id: ObjectId): Promise<Tile> {
-    try {
-      const tile = await this.tileModel.findOne({ _id: id }).populate("price").exec();
-      return tile;
-    } catch {
-      throw new NotFoundException({
-        message: "Tile cannot be find, please search again",
-      });
-    }
+    const tile = await this.tileModel.findOne({ _id: id }).populate("price").exec();
+    return tile;
   }
 
   async create(createTileDto: CreateTileDto): Promise<Tile> {
@@ -33,21 +27,18 @@ export class TilesService {
   }
 
   async update(id: ObjectId, updateTileDto: UpdateTileDto): Promise<Tile> {
-    try {
-      const existingTile = await this.tileModel
-        .findOneAndUpdate({ _id: id }, { $set: updateTileDto }, { new: true })
-        .exec();
-      return existingTile;
-    } catch {
-      throw new NotFoundException({
-        message: "Tile cannot be found, please search again",
-      });
-    }
+    const existingTile = await this.tileModel
+      .findOneAndUpdate({ _id: id }, { $set: updateTileDto }, { new: true })
+      .exec();
+    return existingTile;
   }
 
   async remove(id: ObjectId, updateTileDto: UpdateTileDto): Promise<boolean> {
     try {
-      await this.tileModel.findOneAndUpdate({ _id: id }, { $set: { isDeleted: true } });
+      await this.tileModel.findOneAndUpdate(
+        { _id: id, isDeleted: false },
+        { $set: { isDeleted: true } },
+      );
       return true;
     } catch {
       return false;

--- a/src/tiles/tiles.service.ts
+++ b/src/tiles/tiles.service.ts
@@ -34,14 +34,11 @@ export class TilesService {
   }
 
   async remove(id: ObjectId, updateTileDto: UpdateTileDto): Promise<boolean> {
-    try {
-      await this.tileModel.findOneAndUpdate(
-        { _id: id, isDeleted: false },
-        { $set: { isDeleted: true } },
-      );
-      return true;
-    } catch {
-      return false;
-    }
+    const response = await this.tileModel.findOneAndUpdate(
+      { _id: id, isDeleted: false },
+      { $set: { isDeleted: true } },
+    );
+    if (!response) return false;
+    return true;
   }
 }

--- a/src/tiles/tiles.service.ts
+++ b/src/tiles/tiles.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from "@nestjs/common";
+import { Injectable } from "@nestjs/common";
 import { Model, ObjectId } from "mongoose";
 import { InjectModel } from "@nestjs/mongoose";
 import { Tile } from "./schemas/tile.schema";


### PR DESCRIPTION
**main changes:**
1. Add a new global mongoose error filter to catch the errors caused by mongoose.
2. Optimise some crud functions in services.

From now on, you do not need to handle the mongoose exceptions manually when doing crud actions (like try catch), the global filter will automatically catch the errors for us. The error status code of all kinds of the mongoose errors will be 500, and the message will show the exact error.
If you get an error, the postman/frontend will receive a response like:
<img width="377" alt="Screen Shot 2022-10-24 at 04 35 17" src="https://user-images.githubusercontent.com/86336676/197409626-856b7992-2003-4c35-91a1-8270b70d3bb2.png">

PS. If the mongoDb responses an empty document object (no document fit the search filter && nothing was found), this is not an error. If you want to handle this, you should write something like:
<img width="538" alt="Screen Shot 2022-10-24 at 04 41 48" src="https://user-images.githubusercontent.com/86336676/197409847-fddde6c0-ce31-41a7-a347-15013575f209.png">