### PR TITLE
feat: cc-0107 add auth&role guard

### DIFF
--- a/src/admin/admin.controller.spec.ts
+++ b/src/admin/admin.controller.spec.ts
@@ -5,7 +5,9 @@ import { UpdateAdminDto } from "./dto/update-admin.dto";
 import { AdminController } from "./admin.controller";
 import { AdminService } from "./admin.service";
 import { mockAdminData } from "./admin.testData";
-// import { Admin } from "./schemas/admin.schema";
+import { getModelToken } from "@nestjs/mongoose";
+import { Admin } from "./schemas/admin.schema";
+import { SetAdminPermissionDto } from "./dto/set-admin-permission.dto";
 // import { BadRequestException, NotFoundException } from "@nestjs/common";
 
 describe("AdminController", () => {
@@ -31,7 +33,12 @@ describe("AdminController", () => {
               ),
             remove: jest.fn().mockResolvedValue({ isDeleted: true }),
             restore: jest.fn().mockResolvedValue({ isDeleted: false }),
+            setPermission: jest.fn().mockResolvedValue({ permission: "super" }),
           },
+        },
+        {
+          provide: getModelToken(Admin.name),
+          useValue: jest.fn(),
         },
       ],
     }).compile();
@@ -80,6 +87,15 @@ describe("AdminController", () => {
   it("remove should restore a deleted admin", () => {
     expect(controller.restoreAdminById(Object("634818ff801e2c3713056222"))).resolves.toEqual({
       isDeleted: false,
+    });
+  });
+
+  it("should set a permission state for admin", () => {
+    const setAdminPermissionDto: SetAdminPermissionDto = { permission: "super" };
+    expect(
+      controller.setAdminPermissionById(Object("634818ff801e2c3713056222"), setAdminPermissionDto),
+    ).resolves.toEqual({
+      permission: "super",
     });
   });
 });

--- a/src/admin/admin.controller.ts
+++ b/src/admin/admin.controller.ts
@@ -22,6 +22,11 @@ import { CreateAdminDto } from "./dto/create-admin.dto";
 import { UpdateAdminDto } from "./dto/update-admin.dto";
 import { LoginAdminDto } from "./dto/login-admin.dto";
 import { PaginationQueryDto } from "../utils/PaginationDto/pagination-query.dto";
+import { SetAdminPermissionDto } from "./dto/set-admin-permission.dto";
+import { AuthGuard } from "@nestjs/passport";
+import { HasPermissions } from "src/auth/hasPermission.decorator";
+import { permissionType } from "src/admin/schemas/admin.schema";
+import { PermissionsGuard } from "src/auth/permission.guard";
 
 @Controller("admin")
 export class AdminController {
@@ -46,11 +51,25 @@ export class AdminController {
     return await this.adminService.update(adminId, updateAdminDto);
   }
 
+  @HasPermissions(permissionType.SUPER)
+  @UseGuards(AuthGuard("jwt"), PermissionsGuard)
+  @Patch(":adminId/setPermission")
+  async setAdminPermissionById(
+    @Param("adminId", ParseObjectIdPipe) adminId: ObjectId,
+    @Body() setAdminPermissionDto: SetAdminPermissionDto,
+  ): Promise<boolean> {
+    return await this.adminService.setPermission(adminId, setAdminPermissionDto);
+  }
+
+  @HasPermissions(permissionType.SUPER)
+  @UseGuards(AuthGuard("jwt"), PermissionsGuard)
   @Delete(":adminId")
   async deleteAdminById(@Param("adminId", ParseObjectIdPipe) adminId: ObjectId): Promise<boolean> {
     return await this.adminService.remove(adminId);
   }
 
+  @HasPermissions(permissionType.SUPER)
+  @UseGuards(AuthGuard("jwt"), PermissionsGuard)
   @Patch(":adminId/restore")
   async restoreAdminById(@Param("adminId", ParseObjectIdPipe) adminId: ObjectId): Promise<boolean> {
     return await this.adminService.restore(adminId);

--- a/src/admin/admin.service.spec.ts
+++ b/src/admin/admin.service.spec.ts
@@ -4,7 +4,7 @@ import { AdminService } from "./admin.service";
 import { createMock } from "@golevelup/ts-jest";
 import { Admin } from "./schemas/admin.schema";
 import { getModelToken } from "@nestjs/mongoose";
-import { mockAdminData } from "./admin.testData";
+import { mockAdminData, mockAdminDataWithPermission } from "./admin.testData";
 import { JwtService } from "@nestjs/jwt";
 
 describe("AdminService", () => {
@@ -117,5 +117,18 @@ describe("AdminService", () => {
       }) as any,
     );
     expect(await service.restore(Object("6352457649dfd4dd6e7bb31c"))).toEqual(true);
+  });
+
+  it("should set an admin permission", async () => {
+    const id = Object("634818ff801e2c37130565f3");
+    const spy1 = jest.spyOn(model, "findById").mockReturnValue({
+      exec: jest.fn().mockResolvedValue(mockAdminDataWithPermission),
+    } as any);
+    const spy2 = jest.spyOn(model, "findByIdAndUpdate").mockReturnValue({
+      exec: jest.fn().mockResolvedValue(mockAdminDataWithPermission),
+    } as any);
+    await service.update(id, { permission: "super" });
+    expect(spy1).toBeCalled();
+    expect(spy2).toBeCalled();
   });
 });

--- a/src/admin/admin.service.ts
+++ b/src/admin/admin.service.ts
@@ -9,6 +9,7 @@ import { Model, ObjectId } from "mongoose";
 import { LoginAdminDto } from "./dto/login-admin.dto";
 import { CreateAdminDto } from "./dto/create-admin.dto";
 import { UpdateAdminDto } from "./dto/update-admin.dto";
+import { SetAdminPermissionDto } from "./dto/set-admin-permission.dto";
 import { Admin } from "./schemas/admin.schema";
 import { JwtService } from "@nestjs/jwt";
 import { Tokens } from "./types";
@@ -30,7 +31,6 @@ export class AdminService {
       name: adminDto.name,
       email: adminDto.email,
       password: hashedPassword,
-      permission: adminDto.permission,
     };
     //fetch all users
     const allUsersEmails = await this.adminModel.find().exec();
@@ -169,6 +169,22 @@ export class AdminService {
     }
     await this.adminModel.findByIdAndUpdate(adminId, {
       isDeleted: false,
+      updatedAt: new Date(),
+    });
+    return true;
+  }
+
+  async setPermission(
+    adminId: ObjectId,
+    setAdminPermissionDto: SetAdminPermissionDto,
+  ): Promise<boolean> {
+    const admin = await this.adminModel.findById(adminId).exec();
+
+    if (!admin || admin.isDeleted) {
+      throw new NotFoundException("Admin not found");
+    }
+    await this.adminModel.findByIdAndUpdate(adminId, {
+      permission: setAdminPermissionDto.permission,
       updatedAt: new Date(),
     });
     return true;

--- a/src/admin/admin.testData.ts
+++ b/src/admin/admin.testData.ts
@@ -33,3 +33,16 @@ export const mockAdminData = [
     isDeleted: true,
   },
 ];
+
+export const mockAdminDataWithPermission = {
+  id: "634818ff801e2c37130565f5",
+  email: "admin@gmail.com",
+  permission: "normal",
+  password:
+    "$argon2id$v=19$m=4096,t=3,p=1$qtjGrhycYWpLKboGKdHBhQ$GxfV6BXljUQmyjdWp278o1WOQpVpoBpXe3V4mcfh2ZE",
+  hashedRefreshToken:
+    "$argon2id$v=19$m=4096,t=3,p=1$EGlzfBvesXfKyVQlXtxC+w$eNo5EYb9WNJbZF9UlNsuwI9L6x3fKXMQnrmVnPvabLo",
+  createdAt: "2022-10-12T06:08:47.952Z",
+  updatedAt: "2022-10-12T13:52:54.929Z",
+  isDeleted: false,
+};

--- a/src/admin/dto/create-admin.dto.ts
+++ b/src/admin/dto/create-admin.dto.ts
@@ -1,5 +1,4 @@
-import { IsEmail, IsNotEmpty, IsString, IsEnum } from "class-validator";
-import { permissionType } from "../schemas/admin.schema";
+import { IsEmail, IsNotEmpty, IsString } from "class-validator";
 
 export class CreateAdminDto {
   @IsNotEmpty()
@@ -11,10 +10,6 @@ export class CreateAdminDto {
   readonly password: string;
 
   readonly hashedRefreshToken: string;
-
-  @IsNotEmpty()
-  @IsEnum(permissionType)
-  readonly permission: string;
 
   @IsNotEmpty()
   @IsString()

--- a/src/admin/dto/set-admin-permission.dto.ts
+++ b/src/admin/dto/set-admin-permission.dto.ts
@@ -1,0 +1,8 @@
+import { IsNotEmpty, IsEnum } from "class-validator";
+import { permissionType } from "../schemas/admin.schema";
+
+export class SetAdminPermissionDto {
+  @IsNotEmpty()
+  @IsEnum(permissionType)
+  readonly permission: string;
+}

--- a/src/admin/dto/update-admin.dto.ts
+++ b/src/admin/dto/update-admin.dto.ts
@@ -1,4 +1,11 @@
 import { PartialType } from "@nestjs/mapped-types";
+import { Exclude } from "class-transformer";
 import { CreateAdminDto } from "./create-admin.dto";
 
-export class UpdateAdminDto extends PartialType(CreateAdminDto) {}
+export class UpdateAdminDto extends PartialType(CreateAdminDto) {
+  @Exclude()
+  readonly email: string;
+
+  @Exclude()
+  readonly permission: string;
+}

--- a/src/admin/schemas/admin.schema.ts
+++ b/src/admin/schemas/admin.schema.ts
@@ -20,7 +20,7 @@ export class Admin extends Document {
   @Prop({ default: false })
   isDeleted: boolean;
 
-  @Prop({ type: String, enum: permissionType })
+  @Prop({ type: String, enum: permissionType, default: "normal" })
   permission: string;
 
   @Prop()

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -3,9 +3,11 @@ import { AuthService } from "./auth.service";
 import { AuthController } from "./auth.controller";
 import { MongooseModule } from "@nestjs/mongoose";
 import { User, UserSchema } from "../users/schemas/user.schema";
+import { Admin, AdminSchema } from "src/admin/schemas/admin.schema";
 import { JwtModule } from "@nestjs/jwt";
 import { AccessTokenStrategy, RefreshTokenStrategy } from "./strategies";
 import { UserModule } from "../users/user.module";
+import { PermissionsGuard } from "./permission.guard";
 
 @Module({
   imports: [
@@ -14,12 +16,16 @@ import { UserModule } from "../users/user.module";
         name: User.name,
         schema: UserSchema,
       },
+      {
+        name: Admin.name,
+        schema: AdminSchema,
+      },
     ]),
     JwtModule.register({}),
     forwardRef(() => UserModule),
   ],
   providers: [AuthService, AccessTokenStrategy, RefreshTokenStrategy],
   controllers: [AuthController],
-  exports: [AuthService],
+  exports: [AuthService, PermissionsGuard],
 })
 export class AuthModule {}

--- a/src/auth/hasPermission.decorator.ts
+++ b/src/auth/hasPermission.decorator.ts
@@ -1,0 +1,6 @@
+import { SetMetadata } from "@nestjs/common";
+import { permissionType } from "src/admin/schemas/admin.schema";
+
+export const PERMISSIONS_KEY = "permissions";
+export const HasPermissions = (...permissions: permissionType[]) =>
+  SetMetadata(PERMISSIONS_KEY, permissions);

--- a/src/auth/permission.guard.ts
+++ b/src/auth/permission.guard.ts
@@ -1,0 +1,27 @@
+import { Injectable, CanActivate, ExecutionContext } from "@nestjs/common";
+import { Reflector } from "@nestjs/core";
+import { Admin, permissionType } from "src/admin/schemas/admin.schema";
+import { PERMISSIONS_KEY } from "./hasPermission.decorator";
+import { InjectModel } from "@nestjs/mongoose";
+import { Model } from "mongoose";
+
+@Injectable()
+export class PermissionsGuard implements CanActivate {
+  constructor(
+    private reflector: Reflector,
+    @InjectModel(Admin.name) private readonly AdminModel: Model<Admin>,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const requiredPermissions = this.reflector.getAllAndOverride<permissionType[]>(
+      PERMISSIONS_KEY,
+      [context.getHandler(), context.getClass()],
+    );
+    if (!requiredPermissions) {
+      return true;
+    }
+    const { user } = context.switchToHttp().getRequest();
+    const adminUser = await this.AdminModel.findOne({ email: user.email }).exec();
+    return requiredPermissions.some((permission) => adminUser?.permission?.includes(permission));
+  }
+}

--- a/src/team_members/teamMember.controller.spec.ts
+++ b/src/team_members/teamMember.controller.spec.ts
@@ -54,7 +54,7 @@ describe("Team Member Controller", () => {
     expect(controller).toBeDefined();
   });
 
-  describe("getAllTeamMembers", () => {
+  describe("listTeamMembers", () => {
     it("should get all team members", async () => {
       const listTeamMembersDto: ListTeamMembersDto = { isGrouped: "true", limit: 0, offset: 0 };
       expect(controller.listTeamMembers(listTeamMembersDto)).resolves.toEqual(

--- a/src/team_members/teamMember.service.ts
+++ b/src/team_members/teamMember.service.ts
@@ -10,8 +10,8 @@ import { TeamMember } from "./schemas/teamMembers.schema";
 export class TeamMemberService {
   constructor(@InjectModel(TeamMember.name) private readonly TeamMemberModel: Model<TeamMember>) {}
 
-  async listTeamMembers(getAllTeamMembers: ListTeamMembersDto): Promise<any> {
-    const { isGrouped = "false", limit = 0, offset = 0 } = getAllTeamMembers;
+  async listTeamMembers(listTeamMembers: ListTeamMembersDto): Promise<any> {
+    const { isGrouped = "false", limit = 0, offset = 0 } = listTeamMembers;
     const optionalQuery: { [key: string]: any } = {};
 
     const teamMembers = await this.TeamMemberModel.find({


### PR DESCRIPTION
features:
1. added role/guard decorator
2. fixed part of admin permission logic, fixed updateAdminById API, create setAdminPermission API
3. test fixed
4. add role/guard to some APIs.

--------------------------
The requirements for cc-107 are purely backend. These functions have been tested in postman. If you want to test it, you need to get a jwt access key by creating or logging into the admin account and put it in the authorization header of the request. In this way, your request can pass jwt verification.

Note that these APIs added to permission control require the admin-"super" permission to be called. If you create a new admin account, the default permissions are "normal" and your permissions can only be changed by other "super" admins. Therefore, I suggest that you can simply log into an existing "super" admin account to test.

-------------------------
Since the requirements of this card are purely backend, I haven't made any frontend related changes yet. The request sent by the front end does not contain jwt information, so it cannot pass the authorization verification anyway. Please keep this in mind when testing.