### PR TITLE
Feature/cc 33 add migrate-mongo file to update tile prices for new quotation calculation approach

### DIFF
--- a/migrations/20230609055855-update-price.js
+++ b/migrations/20230609055855-update-price.js
@@ -1,0 +1,22 @@
+module.exports = {
+  async up(db) {
+    await db.collection("prices").updateOne({}, [
+      {
+        $set: {
+          cementFloorPrice: 15000,
+          tilePrices: [
+            {
+              tile_id: "",
+              tileName: "Elite X II",
+              deliveryPrice: 1900,
+              price: { singleTone: 1200, twoTone: 1500, threeTone: 2000 },
+              isDeleted: false,
+            },
+          ],
+          updatedAt: new Date(),
+        },
+      },
+      { $unset: ["tile_id", "deliveryPrice", "tilePrice"] },
+    ]);
+  },
+};


### PR DESCRIPTION
Update tile prices for single-tone, two-tone and three-tone tiles. 

Need to run `npm run migrate-up` to update mongodb database.